### PR TITLE
Keep using old aws-sdk

### DIFF
--- a/mappru.gemspec
+++ b/mappru.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '>= 2.3.0'
+  spec.add_dependency 'aws-sdk', '~> 2'
   spec.add_dependency 'diffy'
   spec.add_dependency 'hash_modern_inspect'
   spec.add_dependency 'hashie'


### PR DESCRIPTION
With the current dependency bundler installs aws-sdk 3.

I found an issue roadworker run fails with route tables with VPC endpoint.

```
[ERROR] missing required option :destination_cidr_block
	/path/to/mappru/vendor/bundle/ruby/2.4.0/gems/aws-sdk-ec2-1.24.0/lib/aws-sdk-ec2/route.rb:350:in `extract_destination_cidr_block'
```
It's raised at `rt.routes` in `Mappru::Exporter#export_route_table`.

There appeared [an issue in aws-sdk-ruby](https://github.com/aws/aws-sdk-ruby/issues/1630) but it's just backlogged.

I confirmed aws-sdk 2 has no such issue, so I want roadworker to stay in aws-sdk 2.
In aws-sdk 2, route with VPC endpoint appears as `nil` in `rt.routes`, while appears as an hash object with `destination_cidr_block: nil` in aws-sdk 3.