### PR TITLE
Ignore propageted route entries

### DIFF
--- a/lib/mappru/exporter.rb
+++ b/lib/mappru/exporter.rb
@@ -62,6 +62,8 @@ class Mappru::Exporter
     sorted_routes.each do |route|
       # Skip "local"
       next if route.gateway_id == 'local'
+      # Skip propagated entry
+      next if route.origin == 'EnableVgwRoutePropagation'
 
       hash = {}
 


### PR DESCRIPTION
In current implementation, all route entries that has propagated = 'yes' are target for apply and dry-run. However these entries cannot be modified by AWS APIs.

So I propose to ignore these entries in exporter.rb. It means that we do not put those entries completely under the control of mappru.