### PR TITLE
Use Aws::Ec2::Client

### DIFF
--- a/lib/mappru.rb
+++ b/lib/mappru.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 require 'diffy'
 require 'hash_modern_inspect'
 require 'hashie'

--- a/mappru.gemspec
+++ b/mappru.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-ec2'
   spec.add_dependency 'diffy'
   spec.add_dependency 'hash_modern_inspect'
   spec.add_dependency 'hashie'


### PR DESCRIPTION
Looks like Aws::Ec2::Resource recognizes some routes incorrectly.  But v3 is broken as told in #1, so we give up Resource and switch to Aws::Ec2::Client.

- Q. Some routes?
- A. Resource returns wrong data even API returns correctly
  - (i.e. VPC endpoint route data is returned for normal CreateRoute origin routes)

- Use Aws::Ec2::Client instead of Aws::Ec2::Resource
- Remove version restriction added at https://github.com/codenize-tools/mappru/pull/1

  Because the latest Aws::Ec2::Client has no problem.  (while Resource is still having issues...)