### PR TITLE
"ignore: true" to ignore specific routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ vpc "vpc-12345678" do
     subnets "subnet-12345678"
     route destination_cidr_block: "0.0.0.0/0", gateway_id: "igw-12345678"
     route destination_cidr_block: "192.168.100.101/32", network_interface_id: "eni-12345678"
+
+    # Ignore changes in routes to specific destinations
+    route destination_cidr_block: "192.168.100.200/32", ignore: true
   end
 
   route_table "bar-rt" do

--- a/lib/mappru/driver.rb
+++ b/lib/mappru/driver.rb
@@ -45,6 +45,11 @@ class Mappru::Driver
   end
 
   def create_route(vpc_id, rt_name, dest_cidr, attrs)
+    if attrs[:ignore]
+      log(:info, "[Difference in ignored route] Create Route `#{vpc_id}` > `#{rt_name}` > `#{dest_cidr}`", color: :yellow)
+      return
+    end
+
     log(:info, "Create Route `#{vpc_id}` > `#{rt_name}` > `#{dest_cidr}`", color: :cyan)
 
     unless @options[:dry_run]
@@ -65,6 +70,15 @@ class Mappru::Driver
   end
 
   def update_route(vpc_id, rt_name, dest_cidr, route, old_route)
+    if route[:ignore]
+      route_except_ignore = route.dup.tap { |_| _.delete(:ignore) }
+      if route_except_ignore != old_route
+        log(:info, "[Difference in ignored route] Update Route `#{vpc_id}` > `#{rt_name}` > `#{dest_cidr}`", color: :yellow)
+        log(:info, diff(old_route, route_except_ignore, color: @options[:color]), color: false)
+      end
+      return
+    end
+
     log(:info, "Update Route `#{vpc_id}` > `#{rt_name}` > `#{dest_cidr}`", color: :green)
     log(:info, diff(old_route, route, color: @options[:color]), color: false)
 


### PR DESCRIPTION
Some routes may be subject to change by other automation tools and
scripts. To avoid any rolling back of such changes or any other unexpected
conflicts, support "ignore" attribute to ignore changes in specific
destinations.